### PR TITLE
Add initial go mod support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,10 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# IDE generated files and folders
+.vscode
+.idea
+
+# OS generated files
+.DS_Store

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,1 @@
+package protobuft

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/linqk/protobuft
+
+go 1.12

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,1 @@
 module github.com/linqk/protobuft
-
-go 1.12


### PR DESCRIPTION
This adds the initial go mod support in the hopes to resolve #1.

- This adds the go `go.mod` file
- This includes a `doc.go` file just to prove `go build` but will later to fleshed out with documentation.
- Also adds a minor update to the `.gitignore` file to exclude some `IDE` and `OS` related files.
